### PR TITLE
Added Coin Flip Example

### DIFF
--- a/coinflip/Makefile
+++ b/coinflip/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/coinflip/capsenseconfig.h
+++ b/coinflip/capsenseconfig.h
@@ -1,0 +1,33 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains configuration/settings for the Gecko SDK-provided
+// "capsense" driver at Gecko_SDK/kits/common/drivers/capsense.c.
+
+#ifndef _CAPSENSECONFIG_H_
+#define _CAPSENSECONFIG_H_
+
+#define ACMP_CAPSENSE                       ACMP0
+#define ACMP_CAPSENSE_CLKEN                 CMU_HFPERCLKEN0_ACMP0
+#define PRS_CH_CTRL_SOURCESEL_ACMP_CAPSENSE PRS_CH_CTRL_SOURCESEL_ACMP0
+#define PRS_CH_CTRL_SIGSEL_ACMPOUT_CAPSENSE PRS_CH_CTRL_SIGSEL_ACMP0OUT
+
+#define ACMP_CHANNELS 2
+
+#define BUTTON0_CHANNEL 0
+#define BUTTON1_CHANNEL 1
+
+#define CAPSENSE_CH_IN_USE { true, true }
+
+#endif // _CAPSENSECONFIG_H_

--- a/coinflip/captouch.h
+++ b/coinflip/captouch.h
@@ -1,0 +1,254 @@
+#include <stdint.h>
+
+/* Bit fields for ACMP CTRL */
+#define _ACMP_CTRL_RESETVALUE              0x47000000UL                         /**< Default value for ACMP_CTRL */
+#define _ACMP_CTRL_MASK                    0xCF03077FUL                         /**< Mask for ACMP_CTRL */
+
+#define _ACMP_CTRL_EN_SHIFT                0                                    /**< Shift value for ACMP_EN */
+#define _ACMP_CTRL_EN_MASK                 0x1UL                                /**< Bit mask for ACMP_EN */
+#define _ACMP_CTRL_EN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+
+#define _ACMP_CTRL_MUXEN_SHIFT             1                                    /**< Shift value for ACMP_MUXEN */
+#define _ACMP_CTRL_MUXEN_MASK              0x2UL                                /**< Bit mask for ACMP_MUXEN */
+#define _ACMP_CTRL_MUXEN_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+
+#define _ACMP_CTRL_INACTVAL_SHIFT          2                                    /**< Shift value for ACMP_INACTVAL */
+#define _ACMP_CTRL_INACTVAL_MASK           0x4UL                                /**< Bit mask for ACMP_INACTVAL */
+#define _ACMP_CTRL_INACTVAL_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_INACTVAL_LOW            0x00000000UL                         /**< Mode LOW for ACMP_CTRL */
+#define _ACMP_CTRL_INACTVAL_HIGH           0x00000001UL                         /**< Mode HIGH for ACMP_CTRL */
+
+#define _ACMP_CTRL_GPIOINV_SHIFT           3                                    /**< Shift value for ACMP_GPIOINV */
+#define _ACMP_CTRL_GPIOINV_MASK            0x8UL                                /**< Bit mask for ACMP_GPIOINV */
+#define _ACMP_CTRL_GPIOINV_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_GPIOINV_NOTINV          0x00000000UL                         /**< Mode NOTINV for ACMP_CTRL */
+#define _ACMP_CTRL_GPIOINV_INV             0x00000001UL                         /**< Mode INV for ACMP_CTRL */
+
+#define _ACMP_CTRL_HYSTSEL_SHIFT           4                                    /**< Shift value for ACMP_HYSTSEL */
+#define _ACMP_CTRL_HYSTSEL_MASK            0x70UL                               /**< Bit mask for ACMP_HYSTSEL */
+#define _ACMP_CTRL_HYSTSEL_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST0           0x00000000UL                         /**< Mode HYST0 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST1           0x00000001UL                         /**< Mode HYST1 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST2           0x00000002UL                         /**< Mode HYST2 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST3           0x00000003UL                         /**< Mode HYST3 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST4           0x00000004UL                         /**< Mode HYST4 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST5           0x00000005UL                         /**< Mode HYST5 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST6           0x00000006UL                         /**< Mode HYST6 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST7           0x00000007UL                         /**< Mode HYST7 for ACMP_CTRL */
+
+#define _ACMP_CTRL_WARMTIME_SHIFT          8                                    /**< Shift value for ACMP_WARMTIME */
+#define _ACMP_CTRL_WARMTIME_MASK           0x700UL                              /**< Bit mask for ACMP_WARMTIME */
+#define _ACMP_CTRL_WARMTIME_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_4CYCLES        0x00000000UL                         /**< Mode 4CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_8CYCLES        0x00000001UL                         /**< Mode 8CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_16CYCLES       0x00000002UL                         /**< Mode 16CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_32CYCLES       0x00000003UL                         /**< Mode 32CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_64CYCLES       0x00000004UL                         /**< Mode 64CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_128CYCLES      0x00000005UL                         /**< Mode 128CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_256CYCLES      0x00000006UL                         /**< Mode 256CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_512CYCLES      0x00000007UL                         /**< Mode 512CYCLES for ACMP_CTRL */
+
+#define _ACMP_CTRL_IRISE_SHIFT             16                                   /**< Shift value for ACMP_IRISE */
+#define _ACMP_CTRL_IRISE_MASK              0x10000UL                            /**< Bit mask for ACMP_IRISE */
+#define _ACMP_CTRL_IRISE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_IRISE_DISABLED          0x00000000UL                         /**< Mode DISABLED for ACMP_CTRL */
+#define _ACMP_CTRL_IRISE_ENABLED           0x00000001UL                         /**< Mode ENABLED for ACMP_CTRL */
+
+#define _ACMP_CTRL_IFALL_SHIFT             17                                   /**< Shift value for ACMP_IFALL */
+#define _ACMP_CTRL_IFALL_MASK              0x20000UL                            /**< Bit mask for ACMP_IFALL */
+#define _ACMP_CTRL_IFALL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_IFALL_DISABLED          0x00000000UL                         /**< Mode DISABLED for ACMP_CTRL */
+#define _ACMP_CTRL_IFALL_ENABLED           0x00000001UL                         /**< Mode ENABLED for ACMP_CTRL */
+
+#define _ACMP_CTRL_BIASPROG_SHIFT          24                                   /**< Shift value for ACMP_BIASPROG */
+#define _ACMP_CTRL_BIASPROG_MASK           0xF000000UL                          /**< Bit mask for ACMP_BIASPROG */
+#define _ACMP_CTRL_BIASPROG_DEFAULT        0x00000007UL                         /**< Mode DEFAULT for ACMP_CTRL */
+
+#define _ACMP_CTRL_HALFBIAS_SHIFT          30                                   /**< Shift value for ACMP_HALFBIAS */
+#define _ACMP_CTRL_HALFBIAS_MASK           0x40000000UL                         /**< Bit mask for ACMP_HALFBIAS */
+#define _ACMP_CTRL_HALFBIAS_DEFAULT        0x00000001UL                         /**< Mode DEFAULT for ACMP_CTRL */
+
+#define _ACMP_CTRL_FULLBIAS_SHIFT          31                                   /**< Shift value for ACMP_FULLBIAS */
+#define _ACMP_CTRL_FULLBIAS_MASK           0x80000000UL                         /**< Bit mask for ACMP_FULLBIAS */
+#define _ACMP_CTRL_FULLBIAS_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+
+
+
+/* Bit fields for ACMP INPUTSEL */
+#define _ACMP_INPUTSEL_RESETVALUE          0x00010080UL                            /**< Default value for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_MASK                0x31013FF7UL                            /**< Mask for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_SHIFT        0                                       /**< Shift value for ACMP_POSSEL */
+#define _ACMP_INPUTSEL_POSSEL_MASK         0x7UL                                   /**< Bit mask for ACMP_POSSEL */
+#define _ACMP_INPUTSEL_POSSEL_DEFAULT      0x00000000UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH0          0x00000000UL                            /**< Mode CH0 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH1          0x00000001UL                            /**< Mode CH1 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH2          0x00000002UL                            /**< Mode CH2 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH3          0x00000003UL                            /**< Mode CH3 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH4          0x00000004UL                            /**< Mode CH4 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH5          0x00000005UL                            /**< Mode CH5 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH6          0x00000006UL                            /**< Mode CH6 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH7          0x00000007UL                            /**< Mode CH7 for ACMP_INPUTSEL */
+
+#define _ACMP_INPUTSEL_NEGSEL_SHIFT        4                                       /**< Shift value for ACMP_NEGSEL */
+#define _ACMP_INPUTSEL_NEGSEL_MASK         0xF0UL                                  /**< Bit mask for ACMP_NEGSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH0          0x00000000UL                            /**< Mode CH0 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH1          0x00000001UL                            /**< Mode CH1 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH2          0x00000002UL                            /**< Mode CH2 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH3          0x00000003UL                            /**< Mode CH3 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH4          0x00000004UL                            /**< Mode CH4 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH5          0x00000005UL                            /**< Mode CH5 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH6          0x00000006UL                            /**< Mode CH6 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH7          0x00000007UL                            /**< Mode CH7 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_DEFAULT      0x00000008UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_1V25         0x00000008UL                            /**< Mode 1V25 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_2V5          0x00000009UL                            /**< Mode 2V5 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_VDD          0x0000000AUL                            /**< Mode VDD for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CAPSENSE     0x0000000BUL                            /**< Mode CAPSENSE for ACMP_INPUTSEL */
+
+#define _ACMP_INPUTSEL_VDDLEVEL_SHIFT      8                                       /**< Shift value for ACMP_VDDLEVEL */
+#define _ACMP_INPUTSEL_VDDLEVEL_MASK       0x3F00UL                                /**< Bit mask for ACMP_VDDLEVEL */
+#define _ACMP_INPUTSEL_VDDLEVEL_DEFAULT    0x00000000UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+
+#define _ACMP_INPUTSEL_LPREF_SHIFT         16                                      /**< Shift value for ACMP_LPREF */
+#define _ACMP_INPUTSEL_LPREF_MASK          0x10000UL                               /**< Bit mask for ACMP_LPREF */
+#define _ACMP_INPUTSEL_LPREF_DEFAULT       0x00000001UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+
+#define _ACMP_INPUTSEL_CSRESEN_SHIFT       24                                      /**< Shift value for ACMP_CSRESEN */
+#define _ACMP_INPUTSEL_CSRESEN_MASK        0x1000000UL                             /**< Bit mask for ACMP_CSRESEN */
+#define _ACMP_INPUTSEL_CSRESEN_DEFAULT     0x00000000UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+
+#define _ACMP_INPUTSEL_CSRESSEL_SHIFT      28                                      /**< Shift value for ACMP_CSRESSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_MASK       0x30000000UL                            /**< Bit mask for ACMP_CSRESSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_DEFAULT    0x00000000UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_RES0       0x00000000UL                            /**< Mode RES0 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_RES1       0x00000001UL                            /**< Mode RES1 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_RES2       0x00000002UL                            /**< Mode RES2 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_RES3       0x00000003UL                            /**< Mode RES3 for ACMP_INPUTSEL */
+
+/** ACMP inputs. Note that scaled VDD and bandgap references can only be used
+ *  as negative inputs. */
+typedef enum
+{
+  /** Channel 0 */
+  acmpChannel0    = _ACMP_INPUTSEL_NEGSEL_CH0,
+  /** Channel 1 */
+  acmpChannel1    = _ACMP_INPUTSEL_NEGSEL_CH1,
+  /** Channel 2 */
+  acmpChannel2    = _ACMP_INPUTSEL_NEGSEL_CH2,
+  /** Channel 3 */
+  acmpChannel3    = _ACMP_INPUTSEL_NEGSEL_CH3,
+  /** Channel 4 */
+  acmpChannel4    = _ACMP_INPUTSEL_NEGSEL_CH4,
+  /** Channel 5 */
+  acmpChannel5    = _ACMP_INPUTSEL_NEGSEL_CH5,
+  /** Channel 6 */
+  acmpChannel6    = _ACMP_INPUTSEL_NEGSEL_CH6,
+  /** Channel 7 */
+  acmpChannel7    = _ACMP_INPUTSEL_NEGSEL_CH7,
+  /** 1.25V internal reference */
+  acmpChannel1V25 = _ACMP_INPUTSEL_NEGSEL_1V25,
+  /** 2.5V internal reference */
+  acmpChannel2V5  = _ACMP_INPUTSEL_NEGSEL_2V5,
+  /** Scaled VDD reference */
+  acmpChannelVDD  = _ACMP_INPUTSEL_NEGSEL_VDD,
+
+  /** Capacitive sense mode */
+  acmpChannelCapSense = _ACMP_INPUTSEL_NEGSEL_CAPSENSE,
+} ACMP_Channel_TypeDef;
+
+typedef enum
+{
+  /** 4 HFPERCLK cycles warmup */
+  acmpWarmTime4   = _ACMP_CTRL_WARMTIME_4CYCLES,
+  /** 8 HFPERCLK cycles warmup */
+  acmpWarmTime8   = _ACMP_CTRL_WARMTIME_8CYCLES,
+  /** 16 HFPERCLK cycles warmup */
+  acmpWarmTime16  = _ACMP_CTRL_WARMTIME_16CYCLES,
+  /** 32 HFPERCLK cycles warmup */
+  acmpWarmTime32  = _ACMP_CTRL_WARMTIME_32CYCLES,
+  /** 64 HFPERCLK cycles warmup */
+  acmpWarmTime64  = _ACMP_CTRL_WARMTIME_64CYCLES,
+  /** 128 HFPERCLK cycles warmup */
+  acmpWarmTime128 = _ACMP_CTRL_WARMTIME_128CYCLES,
+  /** 256 HFPERCLK cycles warmup */
+  acmpWarmTime256 = _ACMP_CTRL_WARMTIME_256CYCLES,
+  /** 512 HFPERCLK cycles warmup */
+  acmpWarmTime512 = _ACMP_CTRL_WARMTIME_512CYCLES
+} ACMP_WarmTime_TypeDef;
+
+
+/** Hysteresis level. See datasheet for your device for details on each
+ *  level. */
+typedef enum
+{
+  acmpHysteresisLevel0 = _ACMP_CTRL_HYSTSEL_HYST0,       /**< Hysteresis level 0 */
+  acmpHysteresisLevel1 = _ACMP_CTRL_HYSTSEL_HYST1,       /**< Hysteresis level 1 */
+  acmpHysteresisLevel2 = _ACMP_CTRL_HYSTSEL_HYST2,       /**< Hysteresis level 2 */
+  acmpHysteresisLevel3 = _ACMP_CTRL_HYSTSEL_HYST3,       /**< Hysteresis level 3 */
+  acmpHysteresisLevel4 = _ACMP_CTRL_HYSTSEL_HYST4,       /**< Hysteresis level 4 */
+  acmpHysteresisLevel5 = _ACMP_CTRL_HYSTSEL_HYST5,       /**< Hysteresis level 5 */
+  acmpHysteresisLevel6 = _ACMP_CTRL_HYSTSEL_HYST6,       /**< Hysteresis level 6 */
+  acmpHysteresisLevel7 = _ACMP_CTRL_HYSTSEL_HYST7        /**< Hysteresis level 7 */
+} ACMP_HysteresisLevel_TypeDef;
+
+
+/** Resistor values used for the internal capacative sense resistor. See the
+ *  datasheet for your device for details on each resistor value. */
+typedef enum
+{
+  acmpResistor0 = _ACMP_INPUTSEL_CSRESSEL_RES0,   /**< Resistor value 0 */
+  acmpResistor1 = _ACMP_INPUTSEL_CSRESSEL_RES1,   /**< Resistor value 1 */
+  acmpResistor2 = _ACMP_INPUTSEL_CSRESSEL_RES2,   /**< Resistor value 2 */
+  acmpResistor3 = _ACMP_INPUTSEL_CSRESSEL_RES3,   /**< Resistor value 3 */
+} ACMP_CapsenseResistor_TypeDef;
+
+/** Capsense initialization structure. */
+struct acmp_capsense_init
+{
+  /** Full bias current. See the ACMP chapter about bias and response time in
+   *  the reference manual for details. */
+  bool                          fullBias;
+
+  /** Half bias current. See the ACMP chapter about bias and response time in
+   *  the reference manual for details. */
+  bool                          halfBias;
+
+  /** Bias current. See the ACMP chapter about bias and response time in the
+   *  reference manual for details. */
+  uint32_t                      biasProg;
+
+  /** Warmup time. This is measured in HFPERCLK cycles and should be
+   *  about 10us in wall clock time. */
+  ACMP_WarmTime_TypeDef         warmTime;
+
+  /** Hysteresis level */
+  ACMP_HysteresisLevel_TypeDef  hysteresisLevel;
+
+  /** Resistor used in the capacative sensing circuit. For values see
+   *  your device datasheet. */
+  ACMP_CapsenseResistor_TypeDef resistor;
+
+  /** Low power reference enabled. This setting, if enabled, reduces the
+   *  power used by the VDD and bandgap references. */
+  bool                          lowPowerReferenceEnabled;
+
+  /** Vdd reference value. VDD_SCALED = (Vdd * VDDLEVEL) / 63.
+   *  Valid values are in the range 0-63. */
+  uint32_t                      vddLevel;
+
+  /** If true, ACMP is being enabled after configuration. */
+  bool                          enable;
+};
+
+#define ACMP_CAPSENSE_INIT_DEFAULT                                            \
+{                                                                             \
+    .fullBias = true,                      /* fullBias */                    \
+    .halfBias = false,                      /* halfBias */                    \
+    .biasProg = 0x7,                        /* biasProg */                    \
+    .warmTime = acmpWarmTime512,            /* 512 cycle warmup to be safe */ \
+    .hysteresisLevel = acmpHysteresisLevel1,                                  \
+    .resistor = acmpResistor0,                                                \
+    .lowPowerReferenceEnabled = false,      /* low power reference */         \
+    .vddLevel = 0x3D,                       /* VDD level */                   \
+    .enable = true                          /* Enable after init. */          \
+}

--- a/coinflip/main.c
+++ b/coinflip/main.c
@@ -17,7 +17,7 @@
 
 // Make this program compatible with Toboot-V2.0
 #include <toboot.h>
-TOBOOT_CONFIGURATION(0);
+TOBOOT_CONFIGURATION(TOBOOT_CONFIG_FLAG_AUTORUN);
 
 #define LED_GREEN_PORT GPIOA
 #define LED_GREEN_PIN GPIO0
@@ -27,6 +27,15 @@ TOBOOT_CONFIGURATION(0);
 #define CAP0B_PIN GPIO12
 #define CAP1B_PORT GPIOE
 #define CAP1B_PIN GPIO13
+
+// Delay after the LED goes on before it turns off
+#define LED_ON_DELAY 1000
+
+// Delay after the LED goes off before the 'coin' can be flipped again
+#define LED_OFF_DELAY 2000
+
+// Minimum values for the capsense detect to work
+#define CAPSENSE_DETECT_MIN 20
 
 #pragma warning "Re-defining TIMER_CC_CTRL_INSEL because it's wrong"
 #undef TIMER_CC_CTRL_INSEL
@@ -324,15 +333,14 @@ int main(int argc, char **argv)
     gpio_set(LED_RED_PORT, LED_RED_PIN);
 
     while (1) {
-        while (g_capsense_generation == last_generation)
-            ;
+        while (g_capsense_generation == last_generation) {};
         last_generation = g_capsense_generation;
 
         if(coin_flip==0) {
-            for (i = 0; i < 4; i++) {
+            for (int i = 0; i < 4; i++) {
                 average += g_channel_values[i];
             }
-            if(average > 40) {
+            if(average > CAPSENSE_DETECT_MIN) {
                 if(tick_count%2==0){
                     gpio_clear(LED_RED_PORT, LED_RED_PIN);
                     coin_flip=1;
@@ -347,11 +355,11 @@ int main(int argc, char **argv)
 
         tick_count++;
 
-        if(tick_count == 1000) {
+        if(tick_count == LED_ON_DELAY) {
             gpio_set(LED_GREEN_PORT, LED_GREEN_PIN);
             gpio_set(LED_RED_PORT, LED_RED_PIN);
             // coin_flip = 0;
-        } else if(tick_count >= 4000) {
+        } else if(tick_count >= LED_OFF_DELAY) {
             coin_flip = 0;
         }
     }

--- a/coinflip/main.c
+++ b/coinflip/main.c
@@ -18,6 +18,8 @@
 // Make this program compatible with Toboot-V2.0
 #include <toboot.h>
 TOBOOT_CONFIGURATION(0);
+// Use below line instead of above to autorun program on inserting Tomu board
+// You will need to connect the outer two button tracks to reprogram again
 // TOBOOT_CONFIGURATION(TOBOOT_CONFIG_FLAG_AUTORUN);
 
 #define LED_GREEN_PORT GPIOA

--- a/coinflip/main.c
+++ b/coinflip/main.c
@@ -17,7 +17,8 @@
 
 // Make this program compatible with Toboot-V2.0
 #include <toboot.h>
-TOBOOT_CONFIGURATION(TOBOOT_CONFIG_FLAG_AUTORUN);
+TOBOOT_CONFIGURATION(0);
+// TOBOOT_CONFIGURATION(TOBOOT_CONFIG_FLAG_AUTORUN);
 
 #define LED_GREEN_PORT GPIOA
 #define LED_GREEN_PIN GPIO0
@@ -82,7 +83,6 @@ static volatile bool g_capsense_running = false;
 // Function prototypes so that our main loop can be at the top of the file for readability purposes
 static void ACMP_CapsenseChannelSet(uint32_t channel);
 static void CAPSENSE_Measure(uint32_t channel);
-static void CAPSENSE_Measure(uint32_t channel);
 void timer0_isr(void);
 void capsense_start(void);
 void capsense_stop(void);
@@ -91,7 +91,7 @@ static void setup_capsense(void);
 static void setup(void);
 
 // Main loop called to 
-int main(int argc, char **argv)
+int main(void)
 {
     uint32_t last_generation = 0;
     uint32_t tick_count = 0;
@@ -183,8 +183,8 @@ static void ACMP_CapsenseChannelSet(uint32_t channel)
                         | ACMP_INPUTSEL_NEGSEL(ACMP_INPUTSEL_NEGSEL_CAPSENSE)
                         | (channel << _ACMP_INPUTSEL_POSSEL_SHIFT);
     }
-    else if (channel == 2) {};
-    else if (channel == 3) {};
+    else if (channel == 2) {}
+    else if (channel == 3) {}
     else
         while(1);
 }
@@ -389,6 +389,10 @@ static void setup(void)
     /* Set up both LEDs as outputs */
     gpio_mode_setup(LED_RED_PORT, GPIO_MODE_WIRED_AND, LED_RED_PIN);
     gpio_mode_setup(LED_GREEN_PORT, GPIO_MODE_WIRED_AND, LED_GREEN_PIN);
+
+    // Disable GPIO for pin PC1 (CAP1A, red LED button).
+    // This pin was enabled as Output by Toboot bootloader, it interferes with the analog comparator.
+    gpio_mode_setup(GPIOC, GPIO_MODE_DISABLE, GPIO1);
 
     setup_capsense();
 }

--- a/coinflip/main.c
+++ b/coinflip/main.c
@@ -1,0 +1,358 @@
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/cm3/vector.h>
+#include <libopencm3/cm3/scb.h>
+#include <libopencm3/efm32/cmu.h>
+#include <libopencm3/efm32/gpio.h>
+#include <libopencm3/efm32/common/prs_common.h>
+#include <libopencm3/efm32/common/acmp_common.h>
+#include <libopencm3/efm32/timer.h>
+#include <libopencm3/efm32/wdog.h>
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "captouch.h"
+#include "capsenseconfig.h"
+
+// Make this program compatible with Toboot-V2.0
+#include <toboot.h>
+TOBOOT_CONFIGURATION(0);
+
+#define LED_GREEN_PORT GPIOA
+#define LED_GREEN_PIN GPIO0
+#define LED_RED_PORT GPIOB
+#define LED_RED_PIN GPIO7
+#define CAP0B_PORT GPIOE
+#define CAP0B_PIN GPIO12
+#define CAP1B_PORT GPIOE
+#define CAP1B_PIN GPIO13
+
+#pragma warning "Re-defining TIMER_CC_CTRL_INSEL because it's wrong"
+#undef TIMER_CC_CTRL_INSEL
+#define TIMER_CC_CTRL_INSEL (1 << 20)
+
+#define EFM_ASSERT(x)
+
+/**************************************************************************//**
+ * @brief This vector stores the latest read values from the ACMP
+ * @param ACMP_CHANNELS Vector of channels.
+ *****************************************************************************/
+static volatile uint32_t g_channel_values[4] = {0};
+
+/**************************************************************************//**
+ * @brief  This stores the maximum values seen by a channel
+ * @param ACMP_CHANNELS Vector of channels.
+ *****************************************************************************/
+static volatile uint32_t channelMaxValues[4] = {0};
+
+/** The current channel we are sensing. */
+static volatile uint8_t g_current_channel;
+
+/** Which generation of capsense we're on.  Monotonically increasing. */
+static volatile uint32_t g_capsense_generation;
+
+/** Set to true when we're freerunning capsense */
+static volatile bool g_capsense_running = false;
+
+/***************************************************************************//**
+ * @brief
+ *   Sets the ACMP channel used for capacative sensing.
+ *
+ * @note
+ *   A basic example of capacative sensing can be found in the STK BSP
+ *   (capsense demo).
+ *
+ * @param[in] acmp
+ *   Pointer to ACMP peripheral register block.
+ *
+ * @param[in] channel
+ *   The ACMP channel to use for capacative sensing (Possel).
+ ******************************************************************************/
+static void ACMP_CapsenseChannelSet(uint32_t channel)
+{
+    g_current_channel = channel;
+
+    if (channel == 0) {
+        MMIO32(ACMP0_INPUTSEL) = (acmpResistor0 << _ACMP_INPUTSEL_CSRESSEL_SHIFT)
+                            | ACMP_INPUTSEL_CSRESEN
+                            | (false << _ACMP_INPUTSEL_LPREF_SHIFT)
+                            | (0x3f << _ACMP_INPUTSEL_VDDLEVEL_SHIFT)
+                            | ACMP_INPUTSEL_NEGSEL(ACMP_INPUTSEL_NEGSEL_CAPSENSE)
+                            | (channel << _ACMP_INPUTSEL_POSSEL_SHIFT);
+    }
+    else if (channel == 1) {
+        MMIO32(ACMP0_INPUTSEL) = (acmpResistor0 << _ACMP_INPUTSEL_CSRESSEL_SHIFT)
+                        | ACMP_INPUTSEL_CSRESEN
+                        | (false << _ACMP_INPUTSEL_LPREF_SHIFT)
+                        | (0x3d << _ACMP_INPUTSEL_VDDLEVEL_SHIFT)
+                        | ACMP_INPUTSEL_NEGSEL(ACMP_INPUTSEL_NEGSEL_CAPSENSE)
+                        | (channel << _ACMP_INPUTSEL_POSSEL_SHIFT);
+    }
+    else if (channel == 2)
+        ;
+    else if (channel == 3)
+        ;
+    else
+        while(1);
+}
+
+/**************************************************************************//**
+ * @brief
+ *   Start a capsense measurement of a specific channel and waits for
+ *   it to complete.
+ *****************************************************************************/
+static void CAPSENSE_Measure(uint32_t channel)
+{
+    /* Set up this channel in the ACMP. */
+    ACMP_CapsenseChannelSet(channel);
+
+    /* Reset timers */
+    TIMER0_CNT = 0;
+    TIMER1_CNT = 0;
+
+    /* Start timers */
+    TIMER0_CMD = TIMER_CMD_START;
+    TIMER1_CMD = TIMER_CMD_START;
+
+    if (channel == 2) {
+        gpio_mode_setup(CAP0B_PORT, GPIO_MODE_PUSH_PULL, CAP0B_PIN);
+        gpio_set(CAP0B_PORT, CAP0B_PIN);
+        gpio_mode_setup(CAP0B_PORT, GPIO_MODE_INPUT, CAP0B_PIN);
+        while (gpio_get(CAP0B_PORT, CAP0B_PIN) && (TIMER0_CNT < (TIMER0_TOP - 5)))
+            ;
+        g_channel_values[channel] = TIMER0_CNT;
+    }
+    else if (channel == 3) {
+        gpio_mode_setup(CAP1B_PORT, GPIO_MODE_PUSH_PULL, CAP1B_PIN);
+        gpio_set(CAP1B_PORT, CAP1B_PIN);
+        gpio_mode_setup(CAP1B_PORT, GPIO_MODE_INPUT, CAP1B_PIN);
+        while (gpio_get(CAP1B_PORT, CAP1B_PIN) && (TIMER0_CNT < (TIMER0_TOP - 5)))
+            ;
+        g_channel_values[channel] = TIMER0_CNT;
+    }
+}
+
+
+/**************************************************************************//**
+ * @brief
+ *   TIMER0 interrupt handler.
+ *
+ * @detail
+ *   When TIMER0 expires the number of pulses on TIMER1 is inserted into
+ *   channelValues. If this values is bigger than what is recorded in
+ *   channelMaxValues, channelMaxValues is updated.
+ *   Finally, the next ACMP channel is selected.
+ *****************************************************************************/
+void timer0_isr(void)
+{
+  uint32_t count;
+
+  /* Stop timers */
+  TIMER0_CMD = TIMER_CMD_STOP;
+  TIMER1_CMD = TIMER_CMD_STOP;
+
+  /* Clear interrupt flag */
+  TIMER0_IFC = TIMER_IFC_OF;
+
+  /* Read out value of TIMER1 */
+  count = TIMER1_CNT;
+
+  /* Store value in channelValues */
+  g_channel_values[g_current_channel] = count;
+
+  /* Update channelMaxValues */
+  if (count > channelMaxValues[g_current_channel])
+    channelMaxValues[g_current_channel] = count;
+
+  if (g_capsense_running) {
+      if (g_current_channel >= 3) {
+          g_capsense_generation++;
+          g_current_channel = 0;
+      }
+      else {
+          g_current_channel++;
+      }
+      CAPSENSE_Measure(g_current_channel);
+  }
+  else {
+      /* Disable the ACMP, since capsense is no longer running */
+      MMIO32(ACMP0_CTRL) &= ~ACMP_CTRL_EN;
+  }
+}
+
+void capsense_start(void) {
+    g_capsense_running = true;
+
+    /* Set the "Enable" Bit in ACMP, so we can make analog measurements */
+    MMIO32(ACMP0_CTRL) |= ACMP_CTRL_EN;
+
+    CAPSENSE_Measure(0);
+}
+
+void capsense_stop(void) {
+    g_capsense_running = false;
+}
+
+/***************************************************************************/ /**
+ * @brief
+ *   Sets up the ACMP for use in capacative sense applications.
+ *
+ * @details
+ *   This function sets up the ACMP for use in capacacitve sense applications.
+ *   To use the capacative sense functionality in the ACMP you need to use
+ *   the PRS output of the ACMP module to count the number of oscillations
+ *   in the capacative sense circuit (possibly using a TIMER).
+ *
+ * @note
+ *   A basic example of capacative sensing can be found in the STK BSP
+ *   (capsense demo).
+ *
+ * @param[in] acmp
+ *   Pointer to ACMP peripheral register block.
+ *
+ * @param[in] init
+ *   Pointer to initialization structure used to configure ACMP for capacative
+ *   sensing operation.
+ ******************************************************************************/
+
+void setup_acmp_capsense(const struct acmp_capsense_init *init)
+{
+    /* Make sure the module exists on the selected chip */
+    EFM_ASSERT(ACMP_REF_VALID(acmp));
+
+    /* Make sure that vddLevel is within bounds */
+    EFM_ASSERT(init->vddLevel < 64);
+
+    /* Make sure biasprog is within bounds */
+    EFM_ASSERT(init->biasProg <=
+               (_ACMP_CTRL_BIASPROG_MASK >> _ACMP_CTRL_BIASPROG_SHIFT));
+
+    /* Set control register. No need to set interrupt modes */
+    MMIO32(ACMP0_CTRL) = (init->fullBias << _ACMP_CTRL_FULLBIAS_SHIFT)
+                        | (init->halfBias << _ACMP_CTRL_HALFBIAS_SHIFT)
+                        | (init->biasProg << _ACMP_CTRL_BIASPROG_SHIFT)
+                        | (init->warmTime << _ACMP_CTRL_WARMTIME_SHIFT)
+                        | (init->hysteresisLevel << _ACMP_CTRL_HYSTSEL_SHIFT)
+        ;
+
+    /* Select capacative sensing mode by selecting a resistor and enabling it */
+    MMIO32(ACMP0_INPUTSEL) = (init->resistor << _ACMP_INPUTSEL_CSRESSEL_SHIFT)
+                        | ACMP_INPUTSEL_CSRESEN
+                        | (init->lowPowerReferenceEnabled << _ACMP_INPUTSEL_LPREF_SHIFT)
+                        | (init->vddLevel << _ACMP_INPUTSEL_VDDLEVEL_SHIFT)
+                        | ACMP_INPUTSEL_NEGSEL(ACMP_INPUTSEL_NEGSEL_CAPSENSE)
+        ;
+
+    /* Enable ACMP if requested. */
+    if (init->enable)
+        MMIO32(ACMP0_CTRL) |= (1 << _ACMP_CTRL_EN_SHIFT);
+}
+
+static void setup_capsense(void)
+{
+    const struct acmp_capsense_init capsenseInit = ACMP_CAPSENSE_INIT_DEFAULT;
+    CMU_HFPERCLKDIV |= CMU_HFPERCLKDIV_HFPERCLKEN;
+    //cmu_periph_clock_enable(CMU_HFPER);
+    cmu_periph_clock_enable(CMU_TIMER0);
+    cmu_periph_clock_enable(CMU_TIMER1);
+
+    CMU_HFPERCLKEN0 |= ACMP_CAPSENSE_CLKEN;
+    cmu_periph_clock_enable(CMU_PRS);
+
+    /* Initialize TIMER0 - Prescaler 2^9, top value 10, interrupt on overflow */
+    TIMER0_CTRL = TIMER_CTRL_PRESC(TIMER_CTRL_PRESC_DIV512);
+    TIMER0_TOP = 10;
+    TIMER0_IEN = TIMER_IEN_OF;
+    TIMER0_CNT = 0;
+
+    /* Initialize TIMER1 - Prescaler 2^10, clock source CC1, top value 0xFFFF */
+    TIMER1_CTRL = TIMER_CTRL_PRESC(TIMER_CTRL_PRESC_DIV1024) | TIMER_CTRL_CLKSEL(TIMER_CTRL_CLKSEL_CC1);
+    TIMER1_TOP  = 0xFFFF;
+
+    /* Set up TIMER1 CC1 to trigger on PRS channel 0 */
+    TIMER1_CC1_CTRL = TIMER_CC_CTRL_MODE(TIMER_CC_CTRL_MODE_INPUTCAPTURE) /* Input capture      */
+                        | TIMER_CC_CTRL_PRSSEL(TIMER_CC_CTRL_PRSSEL_PRSCH0)   /* PRS channel 0      */
+                        | TIMER_CC_CTRL_INSEL           /* PRS input selected */
+                        | TIMER_CC_CTRL_ICEVCTRL(TIMER_CC_CTRL_ICEVCTRL_RISING) /* PRS on rising edge */
+                        | TIMER_CC_CTRL_ICEDGE(TIMER_CC_CTRL_ICEDGE_BOTH);    /* PRS on rising edge */
+
+    /*Set up PRS channel 0 to trigger on ACMP0 output*/
+    PRS_CH0_CTRL = PRS_CH_CTRL_EDSEL_POSEDGE              /* Posedge triggers action */
+                   | PRS_CH_CTRL_SOURCESEL(PRS_CH_CTRL_SOURCESEL_ACMP_CAPSENSE)  /* PRS source */
+                   | PRS_CH_CTRL_SIGSEL(PRS_CH_CTRL_SIGSEL_ACMPOUT_CAPSENSE); /* PRS signal */
+
+    /* Set up ACMP0 in capsense mode */
+    setup_acmp_capsense(&capsenseInit);
+
+    /* Enable TIMER0 interrupt */
+    nvic_enable_irq(NVIC_TIMER0_IRQ);
+}
+
+static void setup(void)
+{
+    /* GPIO peripheral clock is necessary for us to set up the GPIO pins as outputs */
+    cmu_periph_clock_enable(CMU_GPIO);
+
+    /* Set up both LEDs as outputs */
+    gpio_mode_setup(LED_RED_PORT, GPIO_MODE_WIRED_AND, LED_RED_PIN);
+    gpio_mode_setup(LED_GREEN_PORT, GPIO_MODE_WIRED_AND, LED_GREEN_PIN);
+
+    setup_capsense();
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    int i;
+
+    uint32_t last_generation = 0;
+    uint32_t tick_count = 0;
+    uint8_t coin_flip = 0;
+    uint32_t average = 0;
+
+    /* Disable the watchdog that the bootloader started. */
+    WDOG_CTRL = 0;
+
+    setup();
+
+    capsense_start();
+
+    gpio_set(LED_GREEN_PORT, LED_GREEN_PIN);
+    gpio_set(LED_RED_PORT, LED_RED_PIN);
+
+    while (1) {
+        while (g_capsense_generation == last_generation)
+            ;
+        last_generation = g_capsense_generation;
+
+        if(coin_flip==0) {
+            for (i = 0; i < 4; i++) {
+                average += g_channel_values[i];
+            }
+            if(average > 40) {
+                if(tick_count%2==0){
+                    gpio_clear(LED_RED_PORT, LED_RED_PIN);
+                    coin_flip=1;
+                } else {
+                    gpio_clear(LED_GREEN_PORT, LED_GREEN_PIN);
+                    coin_flip=2;
+                }
+                tick_count = 0;
+            }
+            average = 0;
+        }
+
+        tick_count++;
+
+        if(tick_count == 1000) {
+            gpio_set(LED_GREEN_PORT, LED_GREEN_PIN);
+            gpio_set(LED_RED_PORT, LED_RED_PIN);
+            // coin_flip = 0;
+        } else if(tick_count >= 4000) {
+            coin_flip = 0;
+        }
+    }
+}


### PR DESCRIPTION
I thought the Tomu Quickstart repo could benefit from a coinflip functionality, since it's a bit more visceral than just printing numbers to the screen.

I took the capsense functionality directly from the captouch example, and just modified the main loop to randomly select Red or Green LED to light up on the Tomu board when the button is pressed, hold for a short time, and then turn off.

If there are improvements necessary for it to be added to the repo I'm happy to make them happen (to the best of my limited abilities).